### PR TITLE
학습 대화 맥락 유지를 위한 구조화된 Spring AI Chat memory 도입

### DIFF
--- a/adapters/ai/build.gradle.kts
+++ b/adapters/ai/build.gradle.kts
@@ -1,12 +1,5 @@
-dependencyManagement {
-    imports {
-        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
-    }
-}
-
 dependencies {
-    implementation("org.springframework.ai:spring-ai-core:1.0.0-M6")
-    implementation("org.springframework.ai:spring-ai-openai-spring-boot-starter:1.0.0-M6")
+    implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.retry:spring-retry")
 }

--- a/adapters/persistence/build.gradle.kts
+++ b/adapters/persistence/build.gradle.kts
@@ -1,9 +1,3 @@
-dependencyManagement {
-    imports {
-        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
-    }
-}
-
 dependencies {
     implementation(project(":core:domain"))
     api("org.springframework.boot:spring-boot-starter-data-mongodb")

--- a/adapters/persistence/src/main/kotlin/lab/ujumeonji/moco/model/ChatSessionEntity.kt
+++ b/adapters/persistence/src/main/kotlin/lab/ujumeonji/moco/model/ChatSessionEntity.kt
@@ -10,7 +10,7 @@ data class ChatSessionEntity(
     val id: String? = null,
     val challengeId: String,
     val userId: String,
-    val messages: MutableList<MessageEntity> = mutableListOf(),
+    var messages: MutableList<MessageEntity> = mutableListOf(),
     val understandingScore: Int? = null,
     val interactionCount: Int = 0,
     val maxInteractions: Int = 5,

--- a/adapters/persistence/src/main/kotlin/lab/ujumeonji/moco/model/ChatSessionMapper.kt
+++ b/adapters/persistence/src/main/kotlin/lab/ujumeonji/moco/model/ChatSessionMapper.kt
@@ -2,6 +2,7 @@ package lab.ujumeonji.moco.model
 
 import lab.ujumeonji.moco.model.challenge.ChatSession
 import lab.ujumeonji.moco.model.challenge.Message
+import lab.ujumeonji.moco.model.challenge.MessageSender
 import org.springframework.stereotype.Component
 
 @Component
@@ -37,7 +38,7 @@ class ChatSessionMapper {
     private fun MessageEntity.toDomain(): Message {
         return Message(
             content = this.content,
-            sender = this.sender,
+            sender = MessageSender.from(this.sender),
             timestamp = this.timestamp,
         )
     }
@@ -45,7 +46,7 @@ class ChatSessionMapper {
     private fun Message.toEntity(): MessageEntity {
         return MessageEntity(
             content = this.content,
-            sender = this.sender,
+            sender = this.sender.value,
             timestamp = this.timestamp,
         )
     }

--- a/adapters/web/build.gradle.kts
+++ b/adapters/web/build.gradle.kts
@@ -1,20 +1,8 @@
-dependencyManagement {
-    imports {
-        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
-    }
-}
-
 dependencies {
     implementation(project(":core:application"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.data:spring-data-commons")
-    implementation("org.springframework:spring-tx")
-    implementation("io.jsonwebtoken:jjwt-api:0.12.5")
-    implementation("org.slf4j:slf4j-api")
     implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.22")
     implementation("org.springframework.security:spring-security-crypto")
-    implementation("io.jsonwebtoken:jjwt-api:0.12.5")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
 }

--- a/adapters/web/src/main/kotlin/lab/ujumeonji/moco/controller/challenge/dto/ChallengeChatResponse.kt
+++ b/adapters/web/src/main/kotlin/lab/ujumeonji/moco/controller/challenge/dto/ChallengeChatResponse.kt
@@ -29,7 +29,7 @@ data class ChallengeChatResponse(
                     output.messages.map {
                         ChatMessageResponse(
                             content = it.content,
-                            sender = it.sender,
+                            sender = it.sender.value,
                             timestamp = it.timestamp,
                         )
                     },

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -6,12 +6,6 @@ plugins {
     id("io.spring.dependency-management")
 }
 
-dependencyManagement {
-    imports {
-        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
-    }
-}
-
 dependencies {
     implementation(project(":adapters:web"))
     implementation(project(":adapters:persistence"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,20 +20,23 @@ repositories {
 }
 
 extra["jacksonVersion"] = "2.15.4"
+extra["springAiVersion"] = "1.0.3"
+extra["jjwtVersion"] = "0.12.5"
 
-dependencyManagement {
-    imports {
-        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
-    }
-}
-
-allprojects {
+subprojects {
+    apply(plugin = "org.springframework.boot")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
     apply(plugin = "io.spring.dependency-management")
 
     repositories {
         mavenCentral()
+    }
+
+    dependencyManagement {
+        imports {
+            mavenBom("org.springframework.ai:spring-ai-bom:${property("springAiVersion")}")
+        }
     }
 
     java {
@@ -54,22 +57,16 @@ allprojects {
     }
 
     dependencies {
-        testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
         testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
         testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        implementation("org.jetbrains.kotlin:kotlin-reflect")
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${property("jacksonVersion")}")
     }
 
     tasks.withType<Test> {
         useJUnitPlatform()
-    }
-}
-
-subprojects {
-    dependencies {
-        implementation("org.jetbrains.kotlin:kotlin-reflect")
-        implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${property("jacksonVersion")}")
     }
 }
 

--- a/core/application/build.gradle.kts
+++ b/core/application/build.gradle.kts
@@ -1,35 +1,16 @@
-plugins {
-    id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.kotlin.plugin.spring")
-    id("io.spring.dependency-management")
-}
-
-dependencyManagement {
-    imports {
-        mavenBom(org.springframework.boot.gradle.plugin.SpringBootPlugin.BOM_COORDINATES)
-    }
-}
-
 dependencies {
     api(project(":core:domain"))
     implementation(project(":adapters:persistence"))
 
     implementation("org.springframework:spring-context")
-    implementation("org.springframework:spring-tx")
 
     implementation("jakarta.validation:jakarta.validation-api")
     implementation("org.slf4j:slf4j-api")
     implementation("org.springframework.data:spring-data-commons")
-    implementation("org.springframework.ai:spring-ai-core:1.0.0-M6")
+    implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("org.springframework.retry:spring-retry")
     implementation("org.springframework.security:spring-security-crypto")
-    implementation("io.jsonwebtoken:jjwt-api:0.12.5")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
-    implementation("io.swagger.core.v3:swagger-annotations-jakarta:2.2.22")
-
-    testImplementation("org.mockito:mockito-core:5.10.0")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
-    testImplementation("org.assertj:assertj-core:3.25.3")
-    testImplementation("io.mockk:mockk:1.13.9")
+    implementation("io.jsonwebtoken:jjwt-api:${property("jjwtVersion")}")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:${property("jjwtVersion")}")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:${property("jjwtVersion")}")
 }

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/config/AiConfig.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/config/AiConfig.kt
@@ -1,6 +1,9 @@
 package lab.ujumeonji.moco.config
 
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor
+import org.springframework.ai.chat.memory.ChatMemory
+import org.springframework.ai.chat.memory.MessageWindowChatMemory
 import org.springframework.ai.openai.OpenAiChatOptions
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -15,7 +18,10 @@ import java.nio.charset.StandardCharsets
 @EnableConfigurationProperties(AiProperties::class)
 class AiConfig(private val aiProperties: AiProperties) {
     @Bean
-    fun tutorChatClient(builder: ChatClient.Builder): ChatClient =
+    fun tutorChatClient(
+        builder: ChatClient.Builder,
+        memory: ChatMemory,
+    ): ChatClient =
         builder
             .defaultOptions(
                 OpenAiChatOptions.builder()
@@ -25,6 +31,14 @@ class AiConfig(private val aiProperties: AiProperties) {
                     .build(),
             )
             .defaultSystem(loadSystemPrompt())
+            .defaultAdvisors(MessageChatMemoryAdvisor.builder(memory).build())
+            .build()
+
+    @Bean
+    fun chatMemory() =
+        MessageWindowChatMemory.builder()
+            .chatMemoryRepository(xxxxxxxxxxxxxxxxxxxxxxxxxxx)
+            .maxMessages(10)
             .build()
 
     @Bean

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/config/AiConfig.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/config/AiConfig.kt
@@ -1,5 +1,6 @@
 package lab.ujumeonji.moco.config
 
+import lab.ujumeonji.moco.repository.MongoChatMemoryRepository
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor
 import org.springframework.ai.chat.memory.ChatMemory
@@ -17,10 +18,10 @@ import java.nio.charset.StandardCharsets
 @EnableRetry
 @EnableConfigurationProperties(AiProperties::class)
 class AiConfig(private val aiProperties: AiProperties) {
-    @Bean
+    @Bean("tutorChatClient")
     fun tutorChatClient(
         builder: ChatClient.Builder,
-        memory: ChatMemory,
+        chatMemory: ChatMemory,
     ): ChatClient =
         builder
             .defaultOptions(
@@ -31,13 +32,13 @@ class AiConfig(private val aiProperties: AiProperties) {
                     .build(),
             )
             .defaultSystem(loadSystemPrompt())
-            .defaultAdvisors(MessageChatMemoryAdvisor.builder(memory).build())
+            .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
             .build()
 
     @Bean
-    fun chatMemory() =
+    fun chatMemory(mongoChatMemoryRepository: MongoChatMemoryRepository) =
         MessageWindowChatMemory.builder()
-            .chatMemoryRepository(xxxxxxxxxxxxxxxxxxxxxxxxxxx)
+            .chatMemoryRepository(mongoChatMemoryRepository)
             .maxMessages(10)
             .build()
 

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatService.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatService.kt
@@ -8,6 +8,7 @@ import lab.ujumeonji.moco.support.error.BusinessException
 import lab.ujumeonji.moco.support.prompt.PromptTemplateService
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.memory.ChatMemory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.retry.annotation.Backoff
 import org.springframework.retry.annotation.Retryable
@@ -111,23 +112,21 @@ class ChatService(
         userMessage: String,
     ): String {
         return try {
-            val conversationHistory =
-                session.messages
-                    .takeLast(10)
-                    .joinToString("\n") { "${it.sender}: ${it.content}" }
-
             val prompt =
                 promptTemplateService.createPromptFromTemplate(
                     "tutor-response",
                     mapOf(
                         "challengeTitle" to challengeTitle,
                         "challengeDescription" to challengeDescription,
-                        "conversation" to conversationHistory,
                         "userMessage" to userMessage,
                     ),
                 )
 
-            val response = tutorChatClient.prompt(prompt).call()
+            val response =
+                tutorChatClient.prompt(prompt)
+                    .advisors { it.param(ChatMemory.CONVERSATION_ID, session.conversationId) }
+                    .call()
+
             response.content() ?: "죄송합니다. 응답을 생성할 수 없습니다."
         } catch (e: Exception) {
             logger.error("Error generating tutor response", e)

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatService.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatService.kt
@@ -141,7 +141,7 @@ class ChatService(
     )
     private fun calculateUnderstandingScore(messages: List<Message>): Int {
         try {
-            val conversation = messages.joinToString("\n") { "${it.sender}: ${it.content}" }
+            val conversation = messages.joinToString("\n") { "${it.sender.value}: ${it.content}" }
 
             val prompt =
                 promptTemplateService.createPromptFromTemplate(

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/model/challenge/io/ChallengeChatOutput.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/model/challenge/io/ChallengeChatOutput.kt
@@ -1,5 +1,6 @@
 package lab.ujumeonji.moco.service.challenge.io
 
+import lab.ujumeonji.moco.model.challenge.MessageSender
 import java.time.LocalDateTime
 
 data class ChallengeChatOutput(
@@ -14,7 +15,7 @@ data class ChallengeChatOutput(
 ) {
     data class ChatMessage(
         val content: String,
-        val sender: String,
+        val sender: MessageSender,
         val timestamp: LocalDateTime = LocalDateTime.now(),
     )
 

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
@@ -17,13 +17,13 @@ class MongoChatMemoryRepository(
 ) : ChatMemoryRepository {
     private val logger = LoggerFactory.getLogger(MongoChatMemoryRepository::class.java)
 
-    override fun findConversationIds(): List<String?> = chatSessionRepository.findAll().map { it.id }
+    override fun findConversationIds(): List<String> = chatSessionRepository.findAll().mapNotNull { it.id }
 
-    override fun findByConversationId(conversationId: String): List<Message?> {
+    override fun findByConversationId(conversationId: String): List<Message> {
         val session = chatSessionRepository.findByIdOrNull(conversationId) ?: return emptyList()
 
-        return session.messages.map {
-            when (MessageSender.from(it.sender)) {
+        return session.messages.mapNotNull {
+            when (runCatching { MessageSender.from(it.sender) }.getOrNull()) {
                 MessageSender.ASSISTANT, MessageSender.SYSTEM ->
                     AssistantMessage(it.content, mapOf("timestamp" to it.timestamp))
 
@@ -32,6 +32,11 @@ class MongoChatMemoryRepository(
                         .text(it.content)
                         .metadata(mapOf("timestamp" to it.timestamp))
                         .build()
+
+                null -> {
+                    logger.warn("Skipping message with invalid sender: ${it.sender}")
+                    null
+                }
             }
         }
     }

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
@@ -1,0 +1,2 @@
+package lab.ujumeonji.moco.repository 
+

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
@@ -1,2 +1,58 @@
-package lab.ujumeonji.moco.repository 
+package lab.ujumeonji.moco.repository
 
+import lab.ujumeonji.moco.model.MessageEntity
+import org.springframework.ai.chat.memory.ChatMemoryRepository
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.messages.UserMessage
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class MongoChatMemoryRepository(
+    private val chatSessionRepository: ChatSessionRepository,
+) : ChatMemoryRepository {
+    override fun findConversationIds(): List<String?> = chatSessionRepository.findAll().map { it.id }
+
+    override fun findByConversationId(conversationId: String): List<Message?> {
+        val session = chatSessionRepository.findByIdOrNull(conversationId) ?: return emptyList()
+
+        return session.messages.map {
+            when (it.sender) {
+                "assistant" ->
+                    AssistantMessage(
+                        it.content,
+                        mapOf("timestamp" to it.timestamp),
+                    )
+
+                else ->
+                    UserMessage.builder().text(it.content)
+                        .metadata(mapOf("timestamp" to it.timestamp))
+                        .build()
+            }
+        }
+    }
+
+    override fun saveAll(
+        conversationId: String,
+        messages: List<Message>,
+    ) {
+        val messages =
+            messages.map {
+                MessageEntity(
+                    it.text,
+                    it.messageType.value,
+                    it.metadata["timestamp"] as? LocalDateTime ?: LocalDateTime.now(),
+                )
+            }
+
+        val session = chatSessionRepository.findByIdOrNull(conversationId) ?: return
+
+        session.messages = messages.toMutableList()
+
+        chatSessionRepository.save(session)
+    }
+
+    override fun deleteByConversationId(conversationId: String) = chatSessionRepository.deleteById(conversationId)
+}

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
@@ -1,6 +1,7 @@
 package lab.ujumeonji.moco.repository
 
 import lab.ujumeonji.moco.model.MessageEntity
+import lab.ujumeonji.moco.model.challenge.MessageSender
 import org.springframework.ai.chat.memory.ChatMemoryRepository
 import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
@@ -19,15 +20,13 @@ class MongoChatMemoryRepository(
         val session = chatSessionRepository.findByIdOrNull(conversationId) ?: return emptyList()
 
         return session.messages.map {
-            when (it.sender) {
-                "assistant" ->
-                    AssistantMessage(
-                        it.content,
-                        mapOf("timestamp" to it.timestamp),
-                    )
+            when (MessageSender.from(it.sender)) {
+                MessageSender.ASSISTANT, MessageSender.SYSTEM ->
+                    AssistantMessage(it.content, mapOf("timestamp" to it.timestamp))
 
-                else ->
-                    UserMessage.builder().text(it.content)
+                MessageSender.USER ->
+                    UserMessage.builder()
+                        .text(it.content)
                         .metadata(mapOf("timestamp" to it.timestamp))
                         .build()
             }
@@ -38,7 +37,7 @@ class MongoChatMemoryRepository(
         conversationId: String,
         messages: List<Message>,
     ) {
-        val messages =
+        val mappedMessages =
             messages.map {
                 MessageEntity(
                     it.text,
@@ -49,7 +48,7 @@ class MongoChatMemoryRepository(
 
         val session = chatSessionRepository.findByIdOrNull(conversationId) ?: return
 
-        session.messages = messages.toMutableList()
+        session.messages = mappedMessages.toMutableList()
 
         chatSessionRepository.save(session)
     }

--- a/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
+++ b/core/application/src/main/kotlin/lab/ujumeonji/moco/repository/MongoChatMemoryRepository.kt
@@ -2,6 +2,7 @@ package lab.ujumeonji.moco.repository
 
 import lab.ujumeonji.moco.model.MessageEntity
 import lab.ujumeonji.moco.model.challenge.MessageSender
+import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.memory.ChatMemoryRepository
 import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
@@ -14,6 +15,8 @@ import java.time.LocalDateTime
 class MongoChatMemoryRepository(
     private val chatSessionRepository: ChatSessionRepository,
 ) : ChatMemoryRepository {
+    private val logger = LoggerFactory.getLogger(MongoChatMemoryRepository::class.java)
+
     override fun findConversationIds(): List<String?> = chatSessionRepository.findAll().map { it.id }
 
     override fun findByConversationId(conversationId: String): List<Message?> {
@@ -37,6 +40,16 @@ class MongoChatMemoryRepository(
         conversationId: String,
         messages: List<Message>,
     ) {
+        val session = chatSessionRepository.findByIdOrNull(conversationId)
+        if (session == null) {
+            logger.warn(
+                "Skipping chat memory persistence; no session found for conversationId={} (incomingMessages={})",
+                conversationId,
+                messages.size,
+            )
+            return
+        }
+
         val mappedMessages =
             messages.map {
                 MessageEntity(
@@ -45,8 +58,6 @@ class MongoChatMemoryRepository(
                     it.metadata["timestamp"] as? LocalDateTime ?: LocalDateTime.now(),
                 )
             }
-
-        val session = chatSessionRepository.findByIdOrNull(conversationId) ?: return
 
         session.messages = mappedMessages.toMutableList()
 

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    kotlin("jvm") version "1.9.25"
-}
-
-dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib")
-}

--- a/core/domain/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatSession.kt
+++ b/core/domain/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatSession.kt
@@ -37,7 +37,7 @@ class ChatSession(
         messages.add(
             Message(
                 content = content,
-                sender = "user",
+                sender = MessageSender.USER,
                 timestamp = now,
             ),
         )
@@ -50,7 +50,7 @@ class ChatSession(
         messages.add(
             Message(
                 content = content,
-                sender = "assistant",
+                sender = MessageSender.ASSISTANT,
                 timestamp = now,
             ),
         )
@@ -68,8 +68,22 @@ class ChatSession(
     }
 }
 
-class Message(
+data class Message(
     val content: String,
-    val sender: String,
+    val sender: MessageSender,
     val timestamp: LocalDateTime = LocalDateTime.now(),
 )
+
+enum class MessageSender(val value: String) {
+    USER("user"),
+    SYSTEM("system"),
+    ASSISTANT("assistant"),
+    ;
+
+    companion object {
+        fun from(value: String): MessageSender {
+            return entries.firstOrNull { it.value.equals(value, ignoreCase = true) }
+                ?: throw IllegalArgumentException("Unknown message sender: $value")
+        }
+    }
+}

--- a/core/domain/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatSession.kt
+++ b/core/domain/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatSession.kt
@@ -4,10 +4,6 @@ import lab.ujumeonji.moco.model.user.User
 import java.time.LocalDateTime
 import java.util.UUID
 
-interface UnderstandingScoreCalculator {
-    fun calculateScore(messages: List<Message>): Int
-}
-
 class ChatSession(
     val id: String? = null,
     val challengeId: String,
@@ -24,6 +20,9 @@ class ChatSession(
 
     val remainingInteractions: Int
         get() = maxInteractions - interactionCount
+
+    val conversationId: String
+        get() = id ?: UUID.randomUUID().toString()
 
     fun addUserMessage(
         content: String,

--- a/core/domain/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatSession.kt
+++ b/core/domain/src/main/kotlin/lab/ujumeonji/moco/model/challenge/ChatSession.kt
@@ -21,8 +21,10 @@ class ChatSession(
     val remainingInteractions: Int
         get() = maxInteractions - interactionCount
 
+    private var cachedConversationId: String? = null
+
     val conversationId: String
-        get() = id ?: UUID.randomUUID().toString()
+        get() = id ?: cachedConversationId ?: UUID.randomUUID().toString().also { cachedConversationId = it }
 
     fun addUserMessage(
         content: String,


### PR DESCRIPTION
## Summary
- `MongoChatMemoryRepository`를 도입해 대화 이력을 저장하고 AI 응답 맥락을 유지했습니다.
- `AiConfig`를 core application 모듈로 이동하고 Spring AI 의존성을 정리했습니다.
- 각 모듈의 Gradle 의존성을 재정비해 불필요한 선언을 정리했습니다.

## Testing
- [ ] 테스트하지 않음 (요청 없음)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent chat memory with a 10-message window and advisor-backed chat client for improved context and continuity.

* **Breaking Changes**
  * Message sender is now an enum-like value and conversation ID behavior changed, affecting serialized message formats and identifiers.

* **Chores**
  * Gradle build and dependency management reorganized; Spring AI and JWT dependency handling updated across modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->